### PR TITLE
fix .market_exchanges blocking outbound links

### DIFF
--- a/oy_style.css
+++ b/oy_style.css
@@ -666,6 +666,11 @@ a {
         transform:translateX(-50%);
         width:80vh;
         height:40vh;
+        pointer-events: none;
+    }
+
+    .market_exchanges a {
+        pointer-events: all;
     }
 
     .launch_title {


### PR DESCRIPTION
With this commit, the links at the bottom of the site can be clicked.

The `.market_exchanges` element has a higher `z-index` but doesn't need to be clicked, so we can add `pointer-events: none` to it. Since the exchange links still need to be clickable, we can add `pointer-events: all` to them.